### PR TITLE
Sync to hle-client v1.18.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==1.16.0
+hle-client==1.18.0
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
## hle-client v1.18.0 released

Bumps `requirements.txt` from `hle-client==1.16.0` to `hle-client==1.18.0`.

**After merging:** auto-release will create v1.18.0, triggering the build workflow.