### PR TITLE
Fix auto-release version logic

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,13 +24,15 @@ jobs:
       - name: Determine version from requirements.txt
         id: version
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HLE_PAT }}
         run: |
-          CLIENT_VER=$(grep 'hle-client==' requirements.txt | sed 's/hle-client==//')
+          CLIENT_VER=$(grep 'hle-client==' requirements.txt | sed 's/hle-client==//' | tr -d '[:space:]')
           MAJOR_MINOR=$(echo "$CLIENT_VER" | cut -d. -f1-2)
-          EXISTING=$(gh release list --limit 100 | grep -c "v${MAJOR_MINOR}\." || echo "0")
+          EXISTING=$(gh release list --limit 100 --json tagName -q ".[].tagName" | grep -c "^v${MAJOR_MINOR}\." || true)
+          EXISTING=${EXISTING:-0}
           PATCH=$((EXISTING))
           VERSION="${MAJOR_MINOR}.${PATCH}"
+          echo "Detected client=$CLIENT_VER major_minor=$MAJOR_MINOR existing=$EXISTING → v${VERSION}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Fix empty patch digit in auto-release (was producing `v1.18.` instead of `v1.18.0`)
- Use `gh release list --json` for reliable tag parsing
- Trim whitespace from requirements.txt version extraction
- Use HLE_PAT for release list access

## Context
The v1.18.0 auto-release failed with `tag_name is not well-formed` because the version was computed as `1.18.` (empty patch).