### PR TITLE
fix: filter blob-only entries in sync-hle-docker tree query [skip release]

### DIFF
--- a/.github/workflows/sync-hle-docker.yml
+++ b/.github/workflows/sync-hle-docker.yml
@@ -28,7 +28,7 @@ jobs:
           # Sync frontend source
           rm -rf frontend/src frontend/public
           gh api repos/hle-world/hle-docker/git/trees/main?recursive=1 \
-            --jq '.tree[] | select(.path | startswith("frontend/src/") or startswith("frontend/public/")) | .path' \
+            --jq '.tree[] | select(.type == "blob") | select(.path | startswith("frontend/src/") or startswith("frontend/public/")) | .path' \
             | while read -r fpath; do
                 mkdir -p "$(dirname "${fpath}")"
                 curl -sL "https://raw.githubusercontent.com/hle-world/hle-docker/main/${fpath}" -o "${fpath}"


### PR DESCRIPTION
## Problem

The `Sync HLE Docker Changes` workflow has been failing since March 16 with:
```
mkdir: cannot create directory 'frontend/src/api': File exists
```

The GitHub git tree API returns both `blob` (file) and `tree` (directory) entries. The previous jq filter selected all matching paths including directories. When a directory path like `frontend/src/api` is processed, `curl` writes it as a file. The next iteration then tries `mkdir -p frontend/src/api` and fails because it's already a file.

## Fix

Add `.type == "blob"` to the jq filter so only actual files are iterated.

## Impact

This fixes 3 failed dispatch runs from hle-docker (March 16, 17, 18) including the auto-scroll toggle sync.