### PR TITLE
chore: bump hle-client to 1.19.0, align with hle-docker v1.19.2 [skip-release]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==1.18.0
+hle-client==1.19.0
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
## Summary

Bumps `hle-client` to `1.19.0` to align with hle-docker v1.19.2.

All shared backend/frontend files are already in sync (synced via PR #5). This PR only bumps the client version in `requirements.txt`.

After merge, release v1.19.2 will be created manually to match hle-docker's version.