### PR TITLE
fix: restore API key from config on startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,14 @@ async def lifespan(app: FastAPI):
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     (DATA_DIR / "logs").mkdir(exist_ok=True)
     (DATA_DIR / "favicons").mkdir(exist_ok=True)
+    # Restore API key from persisted config if not already set in environment
+    if not os.environ.get("HLE_API_KEY") and HLE_CONFIG.exists():
+        try:
+            api_key = json.loads(HLE_CONFIG.read_text()).get("api_key", "")
+            if api_key:
+                os.environ["HLE_API_KEY"] = api_key
+        except Exception:
+            pass
     await tm.restore_all()
     yield
     await tm.shutdown_all()


### PR DESCRIPTION
## Bug

After container/service restart, adding a tunnel returns:
```
400: {"detail":"API key not configured. Set it in Settings first."}
```
even though the API key is visible and saved in Settings.

## Root cause

`_require_api_key()` checks `os.environ.get("HLE_API_KEY")`. This env var is set when the user saves via Settings, but is lost on process restart. The key is correctly persisted to `hle_config.json` but was never loaded back into the environment on startup.

## Fix

In `lifespan`, before `restore_all()`, load the API key from `hle_config.json` into the environment if `HLE_API_KEY` is not already set.