### PR TITLE
chore: bump hle-client to v2604.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==1.19.0
+hle-client==v2604.1
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
Automated sync from hle-client release vv2604.1.