### PR TITLE
fix: strip v prefix from client version in release workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -27,6 +27,8 @@ jobs:
           GH_TOKEN: ${{ secrets.HLE_PAT }}
         run: |
           CLIENT_VER=$(grep 'hle-client==' requirements.txt | sed 's/hle-client==//' | tr -d '[:space:]')
+          # Strip v prefix if present (safety net)
+          CLIENT_VER="${CLIENT_VER#v}"
           MAJOR_MINOR=$(echo "$CLIENT_VER" | cut -d. -f1-2)
           # Find the highest existing patch for this major.minor and bump by 1
           LATEST=$(gh release list --limit 100 --json tagName -q ".[].tagName" \

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -18,7 +18,9 @@ jobs:
         env:
           CLIENT_VERSION: ${{ github.event.client_payload.version }}
         run: |
-          sed -i "s/hle-client==[0-9.]*/hle-client==${CLIENT_VERSION}/" requirements.txt
+          # Strip v prefix if present (dispatch payload uses tag name e.g. v2604.1)
+          CLEAN_VERSION="${CLIENT_VERSION#v}"
+          sed -i "s/hle-client==[0-9v.]*/hle-client==${CLEAN_VERSION}/" requirements.txt
 
       - name: Create PR
         env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==v2604.1
+hle-client==2604.1
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
## Summary
- Strip `v` prefix from client version in `sync-release.yml` before writing to `requirements.txt`
- Add safety-net `v` prefix strip in `auto-release.yml` version detection
- Fix `requirements.txt` from `hle-client==v2604.1` to `hle-client==2604.1`

The dispatch payload from hle-client uses the tag name (e.g. `v2604.1`), which caused `vv2604.1.0` release tags.

## Test plan
- [ ] Merge this PR — auto-release should create `v2604.1.0` (not `vv2604.1.0`)
- [ ] Verify build workflow runs against correct tag