### PR TITLE
chore: bump hle-client to v2604.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==2604.1
+hle-client==2604.2
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
Automated sync from hle-client release vv2604.2.