### PR TITLE
Add webhook tunnel support

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -23,6 +23,7 @@ class TunnelConfig(BaseModel):
     response_timeout: Optional[int] = None  # server-side response timeout in seconds
     subdomain: Optional[str] = None  # populated once tunnel connects to relay
     zone_domain: Optional[str] = None  # custom zone domain (e.g. "pr.t00t.us")
+    webhook_path: Optional[str] = None  # webhook path prefix (e.g. "/webhook/github")
     server_tunnel_id: Optional[str] = None  # server-assigned UUID
     tier: Optional[str] = None  # billing tier from server
     stopped: bool = False  # persisted: user explicitly stopped this tunnel
@@ -55,6 +56,7 @@ class AddTunnelRequest(_TimeoutValidator):
     upstream_basic_auth: Optional[str] = None
     forward_host: bool = False
     response_timeout: Optional[int] = None
+    webhook_path: Optional[str] = None
 
 
 class UpdateTunnelRequest(_TimeoutValidator):
@@ -68,6 +70,7 @@ class UpdateTunnelRequest(_TimeoutValidator):
     upstream_basic_auth: Optional[str] = None  # set to "" to clear
     forward_host: Optional[bool] = None
     response_timeout: Optional[int] = None
+    webhook_path: Optional[str] = None
 
 
 class UpdateConfigRequest(BaseModel):

--- a/backend/tunnel_manager.py
+++ b/backend/tunnel_manager.py
@@ -57,24 +57,28 @@ def _save_all(tunnels: dict[str, TunnelConfig]) -> None:
 
 async def _spawn(cfg: TunnelConfig) -> asyncio.subprocess.Process:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        "hle",
-        "expose",
-        "--service",
-        cfg.service_url,
-        "--label",
-        cfg.label,
-        "--auth",
-        cfg.auth_mode,
-    ]
-    if cfg.verify_ssl:
-        cmd.append("--verify-ssl")
-    if not cfg.websocket_enabled:
-        cmd.append("--no-websocket")
-    if cfg.upstream_basic_auth:
-        cmd.extend(["--upstream-basic-auth", cfg.upstream_basic_auth])
-    if cfg.forward_host:
-        cmd.append("--forward-host")
+    if cfg.webhook_path:
+        cmd = [
+            "hle", "webhook",
+            "--path", cfg.webhook_path,
+            "--forward-to", cfg.service_url,
+            "--label", cfg.label,
+        ]
+    else:
+        cmd = [
+            "hle", "expose",
+            "--service", cfg.service_url,
+            "--label", cfg.label,
+            "--auth", cfg.auth_mode,
+        ]
+        if cfg.verify_ssl:
+            cmd.append("--verify-ssl")
+        if not cfg.websocket_enabled:
+            cmd.append("--no-websocket")
+        if cfg.upstream_basic_auth:
+            cmd.extend(["--upstream-basic-auth", cfg.upstream_basic_auth])
+        if cfg.forward_host:
+            cmd.append("--forward-host")
     if cfg.response_timeout is not None:
         cmd.extend(["--timeout", str(cfg.response_timeout)])
     env = {**os.environ}
@@ -278,17 +282,20 @@ async def add_tunnel(req: AddTunnelRequest) -> TunnelConfig:
             raise DuplicateLabelError(
                 f"A tunnel with label '{req.label}' already exists"
             )
+    is_webhook = bool(req.webhook_path)
     cfg = TunnelConfig(
         id=uuid.uuid4().hex[:8],
         service_url=req.service_url,
         label=req.label,
         name=req.name,
-        auth_mode=req.auth_mode,
-        verify_ssl=req.verify_ssl,
-        websocket_enabled=req.websocket_enabled,
+        auth_mode="none" if is_webhook else req.auth_mode,
+        verify_ssl=False if is_webhook else req.verify_ssl,
+        websocket_enabled=False if is_webhook else req.websocket_enabled,
         api_key=req.api_key or None,
-        upstream_basic_auth=req.upstream_basic_auth or None,
-        forward_host=req.forward_host,
+        upstream_basic_auth=None if is_webhook else (req.upstream_basic_auth or None),
+        forward_host=False if is_webhook else req.forward_host,
+        response_timeout=req.response_timeout,
+        webhook_path=req.webhook_path,
     )
     proc = await _spawn(cfg)
     _processes[cfg.id] = proc
@@ -374,6 +381,7 @@ async def update_tunnel(tunnel_id: str, req: UpdateTunnelRequest) -> TunnelConfi
     _CONNECTION_FIELDS = {
         "service_url", "label", "verify_ssl", "websocket_enabled",
         "upstream_basic_auth", "forward_host", "response_timeout", "api_key",
+        "webhook_path",
     }
     needs_restart = bool(set(changed.keys()) & _CONNECTION_FIELDS)
 
@@ -505,6 +513,8 @@ def _make_status(tunnel_id: str, cfg: TunnelConfig) -> TunnelStatus:
         public_url = f"https://{cfg.subdomain}.hle.world"
     else:
         public_url = None
+    if public_url and cfg.webhook_path:
+        public_url = f"{public_url}{cfg.webhook_path}"
     return TunnelStatus(
         **cfg.model_dump(),
         state=state,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -12,6 +12,7 @@ export interface TunnelStatus {
   response_timeout: number | null
   subdomain: string | null
   zone_domain: string | null
+  webhook_path: string | null
   server_tunnel_id: string | null
   tier: string | null
   state: 'CONNECTED' | 'CONNECTING' | 'STOPPED' | 'FAILED'
@@ -31,6 +32,7 @@ export interface UpdateTunnelRequest {
   upstream_basic_auth?: string | null
   forward_host?: boolean
   response_timeout?: number | null
+  webhook_path?: string | null
 }
 
 export interface AccessRule {
@@ -84,7 +86,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
 // Tunnels
 export const getTunnels = () => request<TunnelStatus[]>('/tunnels')
-export const addTunnel = (body: { service_url: string; label: string; name?: string; auth_mode: string; verify_ssl?: boolean; websocket_enabled?: boolean; api_key?: string; upstream_basic_auth?: string; forward_host?: boolean; response_timeout?: number }) =>
+export const addTunnel = (body: { service_url: string; label: string; name?: string; auth_mode: string; verify_ssl?: boolean; websocket_enabled?: boolean; api_key?: string; upstream_basic_auth?: string; forward_host?: boolean; response_timeout?: number; webhook_path?: string }) =>
   request<TunnelStatus>('/tunnels', { method: 'POST', body: JSON.stringify(body) })
 export const updateTunnel = (id: string, body: UpdateTunnelRequest) =>
   request<TunnelStatus>(`/tunnels/${id}`, { method: 'PATCH', body: JSON.stringify(body) })

--- a/frontend/src/components/AddTunnelModal.tsx
+++ b/frontend/src/components/AddTunnelModal.tsx
@@ -25,11 +25,22 @@ const btn = (primary: boolean): React.CSSProperties => ({
   background: primary ? 'var(--mint)' : 'var(--surface)', color: primary ? 'var(--bg)' : 'var(--text-dim)',
   fontSize: 14, fontWeight: 500, fontFamily: 'inherit',
 })
+const typeBtn = (active: boolean): React.CSSProperties => ({
+  flex: 1, padding: '8px 0', borderRadius: 6, border: 'none', cursor: 'pointer',
+  background: active ? 'var(--mint)' : 'var(--surface)',
+  color: active ? 'var(--bg)' : 'var(--text-dim)',
+  fontSize: 13, fontWeight: 600, fontFamily: 'inherit',
+  transition: 'background 0.15s, color 0.15s',
+})
+
+type TunnelType = 'expose' | 'webhook'
 
 export function AddTunnelModal({ onClose, onAdded }: Props) {
+  const [tunnelType, setTunnelType] = useState<TunnelType>('expose')
   const [serviceUrl, setServiceUrl] = useState('')
   const [label, setLabel] = useState('')
   const [name, setName] = useState('')
+  const [webhookPath, setWebhookPath] = useState('/webhook/')
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [verifySsl, setVerifySsl] = useState(false)
   const [websocket, setWebsocket] = useState(true)
@@ -40,22 +51,41 @@ export function AddTunnelModal({ onClose, onAdded }: Props) {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
+  const isWebhook = tunnelType === 'webhook'
+
+  const canSubmit = isWebhook
+    ? !!serviceUrl && !!label && !!webhookPath
+    : !!serviceUrl && !!label
+
   async function submit() {
     setLoading(true)
     setError('')
     try {
-      await addTunnel({
-        service_url: serviceUrl,
-        label,
-        name: name || undefined,
-        auth_mode: 'sso',
-        verify_ssl: verifySsl,
-        websocket_enabled: websocket,
-        api_key: apiKeyOverride || undefined,
-        upstream_basic_auth: upstreamBasicAuth || undefined,
-        forward_host: forwardHost || undefined,
-        response_timeout: responseTimeout ? parseInt(responseTimeout, 10) : undefined,
-      })
+      if (isWebhook) {
+        await addTunnel({
+          service_url: serviceUrl,
+          label,
+          name: name || undefined,
+          auth_mode: 'none',
+          websocket_enabled: false,
+          webhook_path: webhookPath,
+          api_key: apiKeyOverride || undefined,
+          response_timeout: responseTimeout ? parseInt(responseTimeout, 10) : undefined,
+        })
+      } else {
+        await addTunnel({
+          service_url: serviceUrl,
+          label,
+          name: name || undefined,
+          auth_mode: 'sso',
+          verify_ssl: verifySsl,
+          websocket_enabled: websocket,
+          api_key: apiKeyOverride || undefined,
+          upstream_basic_auth: upstreamBasicAuth || undefined,
+          forward_host: forwardHost || undefined,
+          response_timeout: responseTimeout ? parseInt(responseTimeout, 10) : undefined,
+        })
+      }
       onAdded()
     } catch (e) {
       setError(String(e))
@@ -69,25 +99,56 @@ export function AddTunnelModal({ onClose, onAdded }: Props) {
       <div style={modal}>
         <h2 style={{ fontSize: 17, fontWeight: 700, fontFamily: 'var(--font-display)' }}>Add Tunnel</h2>
 
+        {/* Tunnel type toggle */}
+        <div style={{ display: 'flex', gap: 6, background: 'var(--surface)', borderRadius: 8, padding: 3 }}>
+          <button style={typeBtn(!isWebhook)} onClick={() => setTunnelType('expose')}>
+            Expose Service
+          </button>
+          <button style={typeBtn(isWebhook)} onClick={() => setTunnelType('webhook')}>
+            Webhook
+          </button>
+        </div>
+
+        {isWebhook && (
+          <div style={fieldStyle}>
+            <label style={labelStyle}>Webhook Path</label>
+            <input style={inputStyle} value={webhookPath}
+              onChange={e => setWebhookPath(e.target.value)}
+              placeholder="/webhook/github" />
+            <span style={{ fontSize: 11, color: 'var(--text-xdim)' }}>
+              Only requests matching this path prefix will be forwarded.
+            </span>
+          </div>
+        )}
+
         <div style={fieldStyle}>
-          <label style={labelStyle}>Service URL</label>
+          <label style={labelStyle}>{isWebhook ? 'Forward To' : 'Service URL'}</label>
           <input style={inputStyle} value={serviceUrl} onChange={e => setServiceUrl(e.target.value)}
-            placeholder="http://192.168.1.50:8096" />
+            placeholder={isWebhook ? 'http://localhost:3000/webhook' : 'http://192.168.1.50:8096'} />
+          {isWebhook && (
+            <span style={{ fontSize: 11, color: 'var(--text-xdim)' }}>
+              Local URL where webhook payloads will be forwarded.
+            </span>
+          )}
         </div>
 
         <div style={fieldStyle}>
           <label style={labelStyle}>Name <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(display only, optional)</span></label>
           <input style={inputStyle} value={name} onChange={e => setName(e.target.value)}
-            placeholder="e.g. Proxmox, Jellyfin, Home Assistant" />
+            placeholder={isWebhook ? 'e.g. GitHub Webhooks, Stripe Events' : 'e.g. Proxmox, Jellyfin, Home Assistant'} />
         </div>
 
         <div style={fieldStyle}>
           <label style={labelStyle}>Label <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(used in subdomain)</span></label>
           <input style={inputStyle} value={label}
             onChange={e => setLabel(e.target.value.toLowerCase().replace(/[_ .]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-{2,}/g, '-'))}
-            placeholder="jellyfin" />
+            placeholder={isWebhook ? 'github-hook' : 'jellyfin'} />
           <span style={{ fontSize: 12, color: 'var(--text-xdim)' }}>
-            Subdomain: <code style={{ color: 'var(--text-dim)', fontFamily: 'var(--font-mono)' }}>{label || 'label'}-<span style={{ opacity: 0.5 }}>xxx</span>.hle.world</code>
+            {isWebhook ? (
+              <>Webhook URL: <code style={{ color: 'var(--text-dim)', fontFamily: 'var(--font-mono)' }}>{label || 'label'}-<span style={{ opacity: 0.5 }}>xxx</span>.hle.world{webhookPath}</code></>
+            ) : (
+              <>Subdomain: <code style={{ color: 'var(--text-dim)', fontFamily: 'var(--font-mono)' }}>{label || 'label'}-<span style={{ opacity: 0.5 }}>xxx</span>.hle.world</code></>
+            )}
           </span>
           <span style={{ fontSize: 11, color: 'var(--text-xdim)' }}>
             Lowercase letters, numbers, and hyphens only. Your unique code is appended automatically.
@@ -104,32 +165,45 @@ export function AddTunnelModal({ onClose, onAdded }: Props) {
 
         {showAdvanced && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12, paddingLeft: 12, borderLeft: '2px solid var(--border)' }}>
-            <label style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', fontSize: 14 }}>
-              <input type="checkbox" checked={verifySsl} onChange={e => setVerifySsl(e.target.checked)} />
-              <span>Verify SSL certificate</span>
-              <span
-                title="By default, SSL verification is disabled so self-signed certificates (common on Proxmox, Unraid, TrueNAS, etc.) work without extra setup. Enable this only if your service has a valid certificate from a trusted CA."
-                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 16, height: 16, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 11, fontWeight: 700, cursor: 'help', userSelect: 'none' }}
-              >?</span>
-            </label>
+            {!isWebhook && (
+              <>
+                <label style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', fontSize: 14 }}>
+                  <input type="checkbox" checked={verifySsl} onChange={e => setVerifySsl(e.target.checked)} />
+                  <span>Verify SSL certificate</span>
+                  <span
+                    title="By default, SSL verification is disabled so self-signed certificates (common on Proxmox, Unraid, TrueNAS, etc.) work without extra setup. Enable this only if your service has a valid certificate from a trusted CA."
+                    style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 16, height: 16, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 11, fontWeight: 700, cursor: 'help', userSelect: 'none' }}
+                  >?</span>
+                </label>
 
-            <label style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', fontSize: 14 }}>
-              <input type="checkbox" checked={websocket} onChange={e => setWebsocket(e.target.checked)} />
-              <span>Enable WebSocket support</span>
-              <span
-                title="Required for services that use WebSockets (Home Assistant, VS Code Server, etc.). Disable only if the service does not support them and you're seeing connection issues."
-                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 16, height: 16, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 11, fontWeight: 700, cursor: 'help', userSelect: 'none' }}
-              >?</span>
-            </label>
+                <label style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', fontSize: 14 }}>
+                  <input type="checkbox" checked={websocket} onChange={e => setWebsocket(e.target.checked)} />
+                  <span>Enable WebSocket support</span>
+                  <span
+                    title="Required for services that use WebSockets (Home Assistant, VS Code Server, etc.). Disable only if the service does not support them and you're seeing connection issues."
+                    style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 16, height: 16, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 11, fontWeight: 700, cursor: 'help', userSelect: 'none' }}
+                  >?</span>
+                </label>
 
-            <label style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', fontSize: 14 }}>
-              <input type="checkbox" checked={forwardHost} onChange={e => setForwardHost(e.target.checked)} />
-              <span>Forward Host header</span>
-              <span
-                title="Forward the browser's Host header to the local service. Enable for services like Home Assistant that validate the Host header against their external_url. By default, the Host header is set from the target URL to avoid 502 errors behind reverse proxies."
-                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 16, height: 16, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 11, fontWeight: 700, cursor: 'help', userSelect: 'none' }}
-              >?</span>
-            </label>
+                <label style={{ display: 'flex', gap: 8, alignItems: 'center', cursor: 'pointer', fontSize: 14 }}>
+                  <input type="checkbox" checked={forwardHost} onChange={e => setForwardHost(e.target.checked)} />
+                  <span>Forward Host header</span>
+                  <span
+                    title="Forward the browser's Host header to the local service. Enable for services like Home Assistant that validate the Host header against their external_url. By default, the Host header is set from the target URL to avoid 502 errors behind reverse proxies."
+                    style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 16, height: 16, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 11, fontWeight: 700, cursor: 'help', userSelect: 'none' }}
+                  >?</span>
+                </label>
+
+                <div style={fieldStyle}>
+                  <label style={{ ...labelStyle, fontSize: 12 }}>
+                    Upstream basic auth <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(optional — user:pass injected into forwarded requests)</span>
+                  </label>
+                  <input style={{ ...inputStyle, fontSize: 13 }} value={upstreamBasicAuth}
+                    onChange={e => setUpstreamBasicAuth(e.target.value)}
+                    placeholder="username:password" type="password" />
+                </div>
+              </>
+            )}
 
             <div style={fieldStyle}>
               <label style={{ ...labelStyle, fontSize: 12 }}>
@@ -142,34 +216,33 @@ export function AddTunnelModal({ onClose, onAdded }: Props) {
 
             <div style={fieldStyle}>
               <label style={{ ...labelStyle, fontSize: 12 }}>
-                Upstream basic auth <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(optional — user:pass injected into forwarded requests)</span>
-              </label>
-              <input style={{ ...inputStyle, fontSize: 13 }} value={upstreamBasicAuth}
-                onChange={e => setUpstreamBasicAuth(e.target.value)}
-                placeholder="username:password" type="password" />
-            </div>
-
-            <div style={fieldStyle}>
-              <label style={{ ...labelStyle, fontSize: 12 }}>
                 Response timeout{' '}
-                <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(seconds — default: 30, max: 1200)</span>
+                <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(seconds — default: {isWebhook ? '120' : '30'}, max: 1200)</span>
               </label>
               <input style={{ ...inputStyle, fontSize: 13 }} value={responseTimeout}
                 onChange={e => setResponseTimeout(e.target.value.replace(/\D/g, ''))}
-                placeholder="30" type="text" inputMode="numeric" />
+                placeholder={isWebhook ? '120' : '30'} type="text" inputMode="numeric" />
               <span style={{ fontSize: 11, color: 'var(--text-xdim)' }}>
-                Increase for services that do heavy processing or trigger long pipelines.
+                {isWebhook
+                  ? 'Time to wait for your service to process the webhook payload.'
+                  : 'Increase for services that do heavy processing or trigger long pipelines.'}
               </span>
             </div>
           </div>
+        )}
+
+        {isWebhook && (
+          <p style={{ fontSize: 12, color: 'var(--text-xdim)', margin: 0, lineHeight: 1.5 }}>
+            Webhook tunnels bypass SSO authentication so external services (GitHub, Stripe, etc.) can deliver payloads. Use webhook signatures from your provider for security.
+          </p>
         )}
 
         {error && <p style={{ color: 'var(--red)', fontSize: 13 }}>{error}</p>}
 
         <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
           <button style={btn(false)} onClick={onClose}>Cancel</button>
-          <button style={btn(true)} onClick={submit} disabled={loading || !serviceUrl || !label}>
-            {loading ? 'Adding...' : 'Add Tunnel'}
+          <button style={btn(true)} onClick={submit} disabled={loading || !canSubmit}>
+            {loading ? 'Adding...' : isWebhook ? 'Add Webhook' : 'Add Tunnel'}
           </button>
         </div>
       </div>

--- a/frontend/src/components/TunnelCard.tsx
+++ b/frontend/src/components/TunnelCard.tsx
@@ -126,6 +126,7 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
   const [editUpstreamBasicAuth, setEditUpstreamBasicAuth] = useState(tunnel.upstream_basic_auth ?? '')
   const [editForwardHost, setEditForwardHost] = useState(tunnel.forward_host)
   const [editResponseTimeout, setEditResponseTimeout] = useState(tunnel.response_timeout?.toString() ?? '')
+  const [editWebhookPath, setEditWebhookPath] = useState(tunnel.webhook_path ?? '')
   const [editSaving, setEditSaving] = useState(false)
 
   const sub = tunnel.subdomain
@@ -161,6 +162,7 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
       setEditUpstreamBasicAuth(tunnel.upstream_basic_auth ?? '')
       setEditForwardHost(tunnel.forward_host)
       setEditResponseTimeout(tunnel.response_timeout?.toString() ?? '')
+      setEditWebhookPath(tunnel.webhook_path ?? '')
     }
     if (p === 'pin') { setNewPin(''); setConfirmPin('') }
     if (p === 'basic-auth') { setBaUsername(''); setBaPassword(''); setBaConfirmPassword('') }
@@ -206,7 +208,14 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
     setEditSaving(true)
     setError('')
     try {
-      await updateTunnel(tunnel.id, {
+      await updateTunnel(tunnel.id, isWebhook ? {
+        service_url: editServiceUrl,
+        label: editLabel,
+        name: editName || undefined,
+        webhook_path: editWebhookPath || undefined,
+        api_key: editApiKey || null,
+        response_timeout: editResponseTimeout ? parseInt(editResponseTimeout, 10) : null,
+      } : {
         service_url: editServiceUrl,
         label: editLabel,
         name: editName || undefined,
@@ -327,6 +336,7 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
   }
 
   const isSso = tunnel.auth_mode === 'sso'
+  const isWebhook = !!tunnel.webhook_path
 
   // Conflict detection helpers
   const pinHasBasicAuthConflict = basicAuth?.has_basic_auth === true
@@ -370,7 +380,7 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
               </span>
             )}
             <span style={{ color: 'var(--text-xdim)', fontWeight: 400, marginLeft: 8, fontSize: 13 }}>
-              {isSso ? '🔒 SSO' : '🌐 Open'}
+              {isWebhook ? '🔗 Webhook' : isSso ? '🔒 SSO' : '🌐 Open'}
             </span>
           </span>
           <span style={{ color: 'var(--text-dim)', fontSize: 12 }}>{tunnel.service_url}</span>
@@ -437,22 +447,22 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
         <button style={btn(panel === 'edit' ? 'active' : 'ghost')} onClick={() => togglePanel('edit')}>
           Edit
         </button>
-        {sub && isSso && (
+        {sub && isSso && !isWebhook && (
           <button style={btn(panel === 'access' ? 'active' : 'ghost')} onClick={() => togglePanel('access')}>
             Access Rules
           </button>
         )}
-        {sub && isSso && (
+        {sub && isSso && !isWebhook && (
           <button style={btn(panel === 'pin' ? 'active' : 'ghost')} onClick={() => togglePanel('pin')}>
             PIN
           </button>
         )}
-        {sub && (
+        {sub && !isWebhook && (
           <button style={btn(panel === 'basic-auth' ? 'active' : 'ghost')} onClick={() => togglePanel('basic-auth')}>
             Basic Auth
           </button>
         )}
-        {sub && (
+        {sub && !isWebhook && (
           <button style={btn(panel === 'share' ? 'active' : 'ghost')} onClick={() => togglePanel('share')}>
             Share
           </button>
@@ -471,12 +481,12 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
       {/* Edit panel */}
       {panel === 'edit' && (
         <div style={section}>
-          <span style={sectionTitle}>Edit Tunnel Settings</span>
+          <span style={sectionTitle}>Edit {isWebhook ? 'Webhook' : 'Tunnel'} Settings</span>
           <span style={{ fontSize: 12, color: 'var(--text-xdim)' }}>Saving will restart the tunnel process.</span>
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>Service URL</label>
+              <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>{isWebhook ? 'Forward To' : 'Service URL'}</label>
               <input style={inputSm} value={editServiceUrl} onChange={e => setEditServiceUrl(e.target.value)} />
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -485,15 +495,22 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
               <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>Display name (optional)</label>
-              <input style={inputSm} value={editName} onChange={e => setEditName(e.target.value)} placeholder="e.g. Home Assistant" />
+              <input style={inputSm} value={editName} onChange={e => setEditName(e.target.value)} placeholder={isWebhook ? 'e.g. GitHub Events' : 'e.g. Home Assistant'} />
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>Auth mode</label>
-              <select style={inputSm} value={editAuthMode} onChange={e => setEditAuthMode(e.target.value as 'sso' | 'none')}>
-                <option value="sso">SSO (recommended)</option>
-                <option value="none">Open (no auth)</option>
-              </select>
-            </div>
+            {isWebhook ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>Webhook Path</label>
+                <input style={inputSm} value={editWebhookPath} onChange={e => setEditWebhookPath(e.target.value)} placeholder="/webhook/github" />
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>Auth mode</label>
+                <select style={inputSm} value={editAuthMode} onChange={e => setEditAuthMode(e.target.value as 'sso' | 'none')}>
+                  <option value="sso">SSO (recommended)</option>
+                  <option value="none">Open (no auth)</option>
+                </select>
+              </div>
+            )}
           </div>
 
           <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
@@ -506,15 +523,17 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
               placeholder="hle_... (optional)" type="password" />
           </div>
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-            <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>
-              Upstream basic auth{' '}
-              <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(user:pass — injected into requests forwarded to the local service)</span>
-            </label>
-            <input style={{ ...inputSm, fontFamily: 'var(--font-mono)' }} value={editUpstreamBasicAuth}
-              onChange={e => setEditUpstreamBasicAuth(e.target.value)}
-              placeholder="username:password (optional)" type="password" />
-          </div>
+          {!isWebhook && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <label style={{ fontSize: 12, color: 'var(--text-dim)' }}>
+                Upstream basic auth{' '}
+                <span style={{ color: 'var(--text-xdim)', fontWeight: 400 }}>(user:pass — injected into requests forwarded to the local service)</span>
+              </label>
+              <input style={{ ...inputSm, fontFamily: 'var(--font-mono)' }} value={editUpstreamBasicAuth}
+                onChange={e => setEditUpstreamBasicAuth(e.target.value)}
+                placeholder="username:password (optional)" type="password" />
+            </div>
+          )}
 
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
             <div>
@@ -524,36 +543,38 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
               </label>
               <input style={inputSm} value={editResponseTimeout}
                 onChange={e => setEditResponseTimeout(e.target.value.replace(/\D/g, ''))}
-                placeholder="30 (default)" type="text" inputMode="numeric" />
+                placeholder={isWebhook ? '120 (default)' : '30 (default)'} type="text" inputMode="numeric" />
             </div>
           </div>
 
-          <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
-            <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer', fontSize: 13 }}>
-              <input type="checkbox" checked={editVerifySsl} onChange={e => setEditVerifySsl(e.target.checked)} />
-              Verify SSL
-              <span
-                title="Enable only if the service has a valid CA-signed certificate. Self-signed certs will fail."
-                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 10, fontWeight: 700, cursor: 'help' }}
-              >?</span>
-            </label>
-            <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer', fontSize: 13 }}>
-              <input type="checkbox" checked={editWebsocket} onChange={e => setEditWebsocket(e.target.checked)} />
-              Enable WebSocket
-              <span
-                title="Required for Home Assistant, VS Code Server, and other services that use WebSockets."
-                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 10, fontWeight: 700, cursor: 'help' }}
-              >?</span>
-            </label>
-            <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer', fontSize: 13 }}>
-              <input type="checkbox" checked={editForwardHost} onChange={e => setEditForwardHost(e.target.checked)} />
-              Forward Host header
-              <span
-                title="Forward the browser's Host header to the local service. Enable for services that validate the Host header (e.g. Home Assistant with external_url)."
-                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 10, fontWeight: 700, cursor: 'help' }}
-              >?</span>
-            </label>
-          </div>
+          {!isWebhook && (
+            <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+              <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer', fontSize: 13 }}>
+                <input type="checkbox" checked={editVerifySsl} onChange={e => setEditVerifySsl(e.target.checked)} />
+                Verify SSL
+                <span
+                  title="Enable only if the service has a valid CA-signed certificate. Self-signed certs will fail."
+                  style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 10, fontWeight: 700, cursor: 'help' }}
+                >?</span>
+              </label>
+              <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer', fontSize: 13 }}>
+                <input type="checkbox" checked={editWebsocket} onChange={e => setEditWebsocket(e.target.checked)} />
+                Enable WebSocket
+                <span
+                  title="Required for Home Assistant, VS Code Server, and other services that use WebSockets."
+                  style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 10, fontWeight: 700, cursor: 'help' }}
+                >?</span>
+              </label>
+              <label style={{ display: 'flex', gap: 6, alignItems: 'center', cursor: 'pointer', fontSize: 13 }}>
+                <input type="checkbox" checked={editForwardHost} onChange={e => setEditForwardHost(e.target.checked)} />
+                Forward Host header
+                <span
+                  title="Forward the browser's Host header to the local service. Enable for services that validate the Host header (e.g. Home Assistant with external_url)."
+                  style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 14, height: 14, borderRadius: '50%', background: 'var(--surface)', color: 'var(--text-dim)', fontSize: 10, fontWeight: 700, cursor: 'help' }}
+                >?</span>
+              </label>
+            </div>
+          )}
 
           <div style={{ display: 'flex', gap: 8 }}>
             <button style={btn('primary')} onClick={handleSaveEdit} disabled={editSaving || !editServiceUrl || !editLabel}>


### PR DESCRIPTION
## Summary
- Branch backend tunnel spawning for `hle webhook` CLI (path prefix, forward-to URL, webhook defaults)
- Add Expose/Webhook toggle to AddTunnelModal with conditional form fields
- Show webhook badge in TunnelCard, hide SSO/PIN/Basic Auth/Share for webhook tunnels
- Webhook edit panel shows only relevant fields (webhook path, forward-to, timeout, API key)

## Test plan
- [ ] Create webhook tunnel via Add Tunnel modal — verify `hle webhook` spawned with correct flags
- [ ] Verify webhook card shows "Webhook" badge and webhook URL with path
- [ ] Verify Access Rules, PIN, Basic Auth, Share buttons hidden for webhooks
- [ ] Edit webhook tunnel — confirm only relevant fields shown
- [ ] Verify existing expose tunnels unchanged