### PR TITLE
chore: bump hle-client to v2604.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==2604.3
+hle-client==2604.4
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
Automated sync from hle-client release vv2604.4.