### PR TITLE
Surface server NOTICE messages in the tunnel UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -132,6 +132,19 @@ async def get_tunnel_logs(tunnel_id: str, lines: int = 100):
     return {"lines": all_lines[-lines:]}
 
 
+@app.get("/api/tunnels/{tunnel_id}/notices")
+async def get_tunnel_notices(tunnel_id: str):
+    """Return recent server-pushed NOTICEs captured for this tunnel.
+
+    The relay streams these over the tunnel WebSocket; the CLI prints them
+    with glyph prefixes (ℹ ✓ ⚠ ✗) which the webapp parses back into
+    structured ``Notice`` records (max 20 per tunnel, oldest → newest).
+    """
+    if tm.get_tunnel(tunnel_id) is None:
+        raise HTTPException(status_code=404, detail="Tunnel not found")
+    return {"notices": tm.get_notices(tunnel_id)}
+
+
 @app.get("/api/tunnels/{tunnel_id}/logs/download")
 async def download_tunnel_logs(tunnel_id: str, lines: int = 2000):
     """Download the last N log lines as a plain text file."""

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal, Optional
 
 from pydantic import BaseModel, field_validator
@@ -95,3 +96,16 @@ class CreateShareLinkRequest(BaseModel):
     duration: Literal["1h", "24h", "7d"] = "24h"
     label: str = ""
     max_uses: Optional[int] = None
+
+
+class Notice(BaseModel):
+    """Server-pushed informational message captured from CLI stdout.
+
+    The relay streams these over the tunnel's control WebSocket; the CLI
+    renders them with glyph prefixes (ℹ ✓ ⚠ ✗). The webapp parses those
+    glyphs back into a structured form for the UI.
+    """
+
+    level: Literal["info", "success", "warning", "error"]
+    message: str
+    ts: datetime

--- a/backend/tunnel_manager.py
+++ b/backend/tunnel_manager.py
@@ -7,10 +7,13 @@ import json
 import os
 import signal
 import uuid
+from collections import deque
+from datetime import datetime, timezone
 from pathlib import Path
 
 from backend.models import (
     AddTunnelRequest,
+    Notice,
     TunnelConfig,
     TunnelStatus,
     UpdateTunnelRequest,
@@ -30,6 +33,30 @@ _user_stopped: set[str] = set()
 
 # Last meaningful error/warning line per tunnel (only WARNING/ERROR level).
 _last_errors: dict[str, str] = {}
+
+# Server-pushed NOTICE messages, ring buffer per tunnel.
+_NOTICE_BUFFER_SIZE = 20
+_last_notices: dict[str, deque[Notice]] = {}
+
+# Map CLI glyph prefix → notice level. The CLI renders notices with these
+# leading characters (see hle_client/notices.py); we recover the level here
+# without coupling to a structured CLI output mode that does not yet exist.
+_NOTICE_GLYPHS: dict[str, str] = {
+    "ℹ": "info",
+    "✓": "success",
+    "⚠": "warning",
+    "✗": "error",
+}
+
+
+def _record_notice(cfg_id: str, level: str, message: str) -> None:
+    buf = _last_notices.setdefault(cfg_id, deque(maxlen=_NOTICE_BUFFER_SIZE))
+    buf.append(Notice(level=level, message=message, ts=datetime.now(timezone.utc)))
+
+
+def get_notices(cfg_id: str) -> list[Notice]:
+    """Return the recent NOTICE buffer for a tunnel (oldest → newest)."""
+    return list(_last_notices.get(cfg_id, ()))
 
 
 # ---------------------------------------------------------------------------
@@ -126,9 +153,19 @@ def _parse_status_line(cfg_id: str, line: str) -> None:
     ``url=https://...`` field of the ``Tunnel registered:`` log line.
     Subdomain (and the rest of the live state) is now fetched
     server-authoritatively via ``GET /api/tunnels/{subdomain}/status``
-    in :func:`_monitor_tunnel`, so this routine only needs to track
-    connection-state transitions visible in the CLI log.
+    in :func:`_monitor_tunnel`, so this routine only tracks
+    connection-state transitions and server-pushed NOTICE messages.
     """
+    # Server NOTICEs are rendered by the CLI with a leading glyph + space.
+    # Match them first so a notice line never falls through to the
+    # WARNING/ERROR string heuristic below.
+    glyph = line[:1]
+    if glyph in _NOTICE_GLYPHS:
+        message = line[1:].strip()
+        if message:
+            _record_notice(cfg_id, _NOTICE_GLYPHS[glyph], message)
+        return
+
     if "Tunnel registered:" in line:
         _connected.add(cfg_id)
         _last_errors.pop(cfg_id, None)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -96,6 +96,14 @@ export const stopTunnel = (id: string) => request<void>(`/tunnels/${id}/stop`, {
 export const getTunnelLogs = (id: string, lines = 200) =>
   request<{ lines: string[] }>(`/tunnels/${id}/logs?lines=${lines}`)
 
+export interface TunnelNotice {
+  level: 'info' | 'success' | 'warning' | 'error'
+  message: string
+  ts: string
+}
+export const getTunnelNotices = (id: string) =>
+  request<{ notices: TunnelNotice[] }>(`/tunnels/${id}/notices`)
+
 // Access rules
 export const getAccessRules = (subdomain: string) => request<AccessRule[]>(`/tunnels/${subdomain}/access`)
 export const addAccessRule = (subdomain: string, email: string, provider: string) =>

--- a/frontend/src/components/TunnelCard.tsx
+++ b/frontend/src/components/TunnelCard.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useRef } from 'react'
-import type { TunnelStatus, AccessRule, ShareLink, BasicAuthStatus } from '../api/client'
+import type { TunnelStatus, AccessRule, ShareLink, BasicAuthStatus, TunnelNotice } from '../api/client'
 import {
   startTunnel, stopTunnel, removeTunnel, updateTunnel,
   getAccessRules, addAccessRule, deleteAccessRule,
   getPinStatus, setPin, removePin,
   getBasicAuthStatus, setBasicAuth, removeBasicAuth,
   getShareLinks, createShareLink, deleteShareLink,
-  getTunnelLogs,
+  getTunnelLogs, getTunnelNotices,
 } from '../api/client'
 import { StatusBadge } from './StatusBadge'
 
@@ -47,7 +47,7 @@ const confirmBox: React.CSSProperties = {
   padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8,
 }
 
-type Panel = 'access' | 'pin' | 'basic-auth' | 'share' | 'logs' | 'edit' | null
+type Panel = 'access' | 'pin' | 'basic-auth' | 'share' | 'logs' | 'notices' | 'edit' | null
 
 export function TunnelCard({ tunnel, onRefresh }: Props) {
   const [panel, setPanel] = useState<Panel>(null)
@@ -99,6 +99,23 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
     const id = setInterval(fetchLogs, 3000)
     return () => clearInterval(id)
   }, [panel, tunnel.id])
+
+  // Notices (server-pushed informational messages, parsed from CLI stdout).
+  const [notices, setNotices] = useState<TunnelNotice[]>([])
+  useEffect(() => {
+    let cancelled = false
+    const fetchNotices = async () => {
+      try {
+        const result = await getTunnelNotices(tunnel.id)
+        if (!cancelled) setNotices(result.notices)
+      } catch { /* ignore */ }
+    }
+    fetchNotices()
+    const id = setInterval(fetchNotices, 5000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [tunnel.id])
+  const noticeCount = notices.length
+  const hasUrgent = notices.some(n => n.level === 'warning' || n.level === 'error')
 
   // Auto-scroll logs to bottom when new content arrives (only if enabled)
   useEffect(() => {
@@ -470,6 +487,15 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
         <button style={btn(panel === 'logs' ? 'active' : 'ghost')} onClick={() => togglePanel('logs')}>
           Logs
         </button>
+        {noticeCount > 0 && (
+          <button
+            style={btn(panel === 'notices' ? 'active' : (hasUrgent ? 'danger' : 'ghost'))}
+            onClick={() => togglePanel('notices')}
+            title="Server-pushed notices for this tunnel"
+          >
+            Notices ({noticeCount})
+          </button>
+        )}
         <button style={{ ...btn('danger'), marginLeft: 'auto' }}
           onClick={() => removeTunnel(tunnel.id).then(onRefresh)}>
           Remove
@@ -832,6 +858,39 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
               ? 'No log output yet.'
               : (logs ?? []).join('\n')}
           </pre>
+        </div>
+      )}
+
+      {panel === 'notices' && (
+        <div style={section}>
+          <div style={sectionTitle}>Server notices</div>
+          {notices.length === 0 ? (
+            <div style={{ fontSize: 13, color: 'var(--text-dim)' }}>No notices.</div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {[...notices].reverse().map((n, i) => {
+                const colour =
+                  n.level === 'error' ? 'var(--red)' :
+                  n.level === 'warning' ? 'var(--yellow)' :
+                  n.level === 'success' ? 'var(--mint)' :
+                  'var(--text-dim)'
+                const glyph =
+                  n.level === 'error' ? '✗' :
+                  n.level === 'warning' ? '⚠' :
+                  n.level === 'success' ? '✓' :
+                  'ℹ'
+                return (
+                  <div key={i} style={{ display: 'flex', gap: 8, fontSize: 13, alignItems: 'baseline' }}>
+                    <span style={{ color: colour, width: 14, flexShrink: 0 }}>{glyph}</span>
+                    <span style={{ flex: 1 }}>{n.message}</span>
+                    <span style={{ color: 'var(--text-dim)', fontSize: 11, flexShrink: 0 }}>
+                      {new Date(n.ts).toLocaleTimeString()}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
Closes #35. Surface server-pushed NOTICE messages in the tunnel UI by parsing them out of the CLI's stdout (glyph-prefixed) and exposing a structured endpoint + a small inline panel.

## Why
The relay began streaming informational messages over each tunnel's control WebSocket in [hle v2604.12](https://github.com/jspanos/hle/releases/tag/v2604.12) (auto-protect applied, dashboard settings changed, tunnel public warnings, etc.). The CLI renders them inline (`ℹ ✓ ⚠ ✗ message`); they currently land in the per-tunnel log file but were invisible to the React UI.

## Changes

### Backend
- **`models.py`** — new `Notice` model (`level`, `message`, `ts`).
- **`tunnel_manager.py`**
  - Glyph-keyed map (`ℹ ✓ ⚠ ✗` → `info|success|warning|error`).
  - Per-tunnel ring buffer (`deque`, max 20).
  - `_parse_status_line` matches the leading glyph **before** the WARNING/ERROR string heuristic so a notice line never bubbles up as `_last_errors`.
  - `get_notices(cfg_id)` accessor for the route.
- **`main.py`** — new `GET /api/tunnels/{id}/notices` returning `{notices: Notice[]}`.

### Frontend
- **`api/client.ts`** — `TunnelNotice` type + `getTunnelNotices(id)`.
- **`TunnelCard.tsx`** — polls `/notices` every 5s, shows a `Notices (N)` button (red when warnings/errors are present), inline panel listing entries newest-first with glyph + colour + timestamp.

## Notes
- Bounded ring buffer means long-running tunnels don't leak memory.
- Glyph parsing is the v1 transport; a structured `--notices-json` CLI mode could replace it later if we ever want richer metadata. Issue text already flagged this as a follow-up.
- The button only renders when there's at least one notice to keep cards quiet.

## Test plan
- [x] Backend imports clean against `hle-client==2604.4` and the rest of runtime deps.
- [x] `Notice` model round-trips through Pydantic.
- [ ] In dev with hle.world on v2604.12: connect a tunnel, toggle auto-protect in dashboard, observe the `Notices (1)` button appear and the inline panel show the message.
