### PR TITLE
fix: trust server's public_url instead of reconstructing it

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -23,7 +23,8 @@ class TunnelConfig(BaseModel):
     forward_host: bool = False  # forward browser's Host header to local service
     response_timeout: Optional[int] = None  # server-side response timeout in seconds
     subdomain: Optional[str] = None  # populated once tunnel connects to relay
-    zone_domain: Optional[str] = None  # custom zone domain (e.g. "pr.t00t.us")
+    public_url: Optional[str] = None  # server-authoritative public URL (no client-side construction)
+    zone_domain: Optional[str] = None  # custom zone domain — informational only, never used to build URLs
     webhook_path: Optional[str] = None  # webhook path prefix (e.g. "/webhook/github")
     server_tunnel_id: Optional[str] = None  # server-assigned UUID
     tier: Optional[str] = None  # billing tier from server
@@ -33,7 +34,6 @@ class TunnelConfig(BaseModel):
 class TunnelStatus(TunnelConfig):
     state: Literal["CONNECTED", "CONNECTING", "STOPPED", "FAILED"] = "STOPPED"
     error: Optional[str] = None  # last error line from log when state is FAILED
-    public_url: Optional[str] = None
     pid: Optional[int] = None
 
 

--- a/backend/tunnel_manager.py
+++ b/backend/tunnel_manager.py
@@ -204,8 +204,11 @@ async def _monitor_tunnel(cfg_id: str, service_url: str, label: str) -> None:
                         tunnels = _load_all()
                         if cfg_id in tunnels:
                             tunnels[cfg_id].subdomain = subdomain
-                            # Enrich with server-authoritative fields
-                            tunnels[cfg_id].zone_domain = t.get("zone_domain")
+                            # Enrich with server-authoritative fields. The relay
+                            # is the source of truth for public_url — never
+                            # reconstruct it client-side.
+                            tunnels[cfg_id].public_url = t.get("public_url")
+                            tunnels[cfg_id].zone_domain = t.get("zone")
                             tunnels[cfg_id].server_tunnel_id = t.get("tunnel_id")
                             tunnels[cfg_id].tier = t.get("tier")
                             _save_all(tunnels)
@@ -263,16 +266,19 @@ async def _monitor_tunnel(cfg_id: str, service_url: str, label: str) -> None:
 
         # Refresh server-authoritative fields. tier no longer flows through
         # /status (it's account-wide, not per-tunnel) so we leave it alone.
+        # public_url is the source of truth — never reconstructed locally.
         changed = False
-        for field in ("zone_domain", "auth_mode"):
-            val = status.get("zone" if field == "zone_domain" else field)
-            if val is not None and getattr(cfg, field, None) != val:
-                setattr(cfg, field, val)
+        server_to_local = {
+            "public_url": "public_url",
+            "zone": "zone_domain",
+            "auth_mode": "auth_mode",
+            "subdomain": "subdomain",
+        }
+        for server_key, local_attr in server_to_local.items():
+            val = status.get(server_key)
+            if val is not None and getattr(cfg, local_attr, None) != val:
+                setattr(cfg, local_attr, val)
                 changed = True
-        new_sub = status.get("subdomain")
-        if new_sub and cfg.subdomain != new_sub:
-            cfg.subdomain = new_sub
-            changed = True
         if changed:
             _save_all(tunnels)
 
@@ -398,6 +404,7 @@ async def update_tunnel(tunnel_id: str, req: UpdateTunnelRequest) -> TunnelConfi
 
     if label_or_url_changed:
         cfg.subdomain = None
+        cfg.public_url = None
         cfg.zone_domain = None
         cfg.server_tunnel_id = None
         # Clear cached favicon when service URL changes
@@ -548,18 +555,16 @@ def _make_status(tunnel_id: str, cfg: TunnelConfig) -> TunnelStatus:
         state = "CONNECTING"
         error = _last_errors.get(tunnel_id)
 
-    if cfg.subdomain and cfg.zone_domain:
-        public_url = f"https://{cfg.subdomain}.{cfg.zone_domain}"
-    elif cfg.subdomain:
-        public_url = f"https://{cfg.subdomain}.hle.world"
-    else:
-        public_url = None
+    # public_url is server-authoritative (set during /status sync).
+    # For webhook tunnels, the server returns the base URL — append the path.
+    public_url = cfg.public_url
     if public_url and cfg.webhook_path:
         public_url = f"{public_url}{cfg.webhook_path}"
+    payload = cfg.model_dump()
+    payload["public_url"] = public_url
     return TunnelStatus(
-        **cfg.model_dump(),
+        **payload,
         state=state,
         error=error,
-        public_url=public_url,
         pid=proc.pid if running else None,
     )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,13 +11,13 @@ export interface TunnelStatus {
   forward_host: boolean
   response_timeout: number | null
   subdomain: string | null
+  public_url: string | null
   zone_domain: string | null
   webhook_path: string | null
   server_tunnel_id: string | null
   tier: string | null
   state: 'CONNECTED' | 'CONNECTING' | 'STOPPED' | 'FAILED'
   error: string | null
-  public_url: string | null
   pid: number | null
 }
 

--- a/frontend/src/components/TunnelCard.tsx
+++ b/frontend/src/components/TunnelCard.tsx
@@ -415,7 +415,7 @@ export function TunnelCard({ tunnel, onRefresh }: Props) {
           )}
           {tunnel.subdomain && !tunnel.public_url && (
             <span style={{ color: 'var(--text-xdim)', fontSize: 12, fontFamily: 'var(--font-mono)' }}>
-              {tunnel.subdomain}.{tunnel.zone_domain || 'hle.world'}
+              {tunnel.subdomain}
             </span>
           )}
         </div>


### PR DESCRIPTION
## Summary
The relay is the source of truth for a tunnel's public URL. The webapp was reconstructing it from \`subdomain\` + \`zone_domain\` + a hard-coded \`.hle.world\` fallback, which produced wrong URLs in two cases:

1. **Right after registration, before the first /status sync**: the \`list_tunnels\` path read \`t.get("zone_domain")\` but the server field is \`zone\`. The field-name mismatch left \`zone_domain=None\`, so the URL fell back to \`https://<subdomain>.hle.world\` — wrong for any tunnel on a custom zone.
2. **With stale persisted data** where \`zone_domain\` had been stored as a full FQDN (e.g. with \`.hle.world\` baked in), the construction produced doubled-up suffixes.

## Fix
- Persist \`public_url\` on \`TunnelConfig\`.
- Populate it from the server in both ingestion paths (\`list_tunnels\` and \`/status\`).
- \`_make_status\` passes the server-supplied \`public_url\` straight through; for webhook tunnels it appends \`webhook_path\` (server returns the base URL there).
- \`zone_domain\` stays as informational metadata but is never used to build URLs.
- Frontend fallback when \`public_url\` is null shows just \`<subdomain>\` instead of guessing the suffix — that branch only shows for ~2 s during initial registration.

## Test plan
- [ ] Verify a tunnel on a custom zone shows the correct \`https://<label>.<zone>\` URL after registration (no more \`.hle.world\` suffix)
- [ ] Verify a tunnel on the default \`hle.world\` zone shows \`https://<sub>-<code>.hle.world\` correctly
- [ ] Verify webhook URL still has the path appended (\`<base>/<webhook_path>\`)
- [ ] Verify edits to label/service_url clear the cached \`public_url\`