### PR TITLE
feat: VITE_APP_MODE preset for ha-addon vs docker variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,17 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build frontend (default/docker)
+      - name: Install frontend deps
         working-directory: frontend
-        run: |
-          npm ci
-          npm run build
+        run: npm ci
 
-      - name: Package webapp tarball
+      - name: Build frontend (docker variant)
+        working-directory: frontend
+        env:
+          VITE_APP_MODE: docker
+        run: npm run build
+
+      - name: Package webapp tarball + docker frontend
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -56,15 +60,20 @@ jobs:
           cp requirements.txt "${DIRNAME}/"
           chmod +x "${DIRNAME}/run.sh"
           tar czf "hle-webapp-${VERSION}.tar.gz" "${DIRNAME}"
+          tar czf "hle-frontend-docker-${VERSION}.tar.gz" -C frontend/dist .
 
-      - name: Package frontend tarballs for distribution repos
+      - name: Build frontend (ha-addon variant)
+        working-directory: frontend
+        env:
+          VITE_APP_MODE: ha-addon
+        run: |
+          rm -rf dist
+          npm run build
+
+      - name: Package ha-addon frontend
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Docker frontend — same as default build (no feature flags yet)
-          tar czf "hle-frontend-docker-${VERSION}.tar.gz" -C frontend/dist .
-
-          # HA addon frontend — same build for now (VITE_APP_MODE not yet implemented)
           tar czf "hle-frontend-ha-addon-${VERSION}.tar.gz" -C frontend/dist .
 
       - name: Upload release assets

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from './api/client'
 import { TunnelCard } from './components/TunnelCard'
 import { AddTunnelModal } from './components/AddTunnelModal'
+import { preset } from './preset'
 
 // ---------------------------------------------------------------------------
 // Shared inline style helpers (reference CSS variables from index.css)
@@ -233,7 +234,7 @@ export default function App() {
           </span>
         </span>
         <span style={{ color: 'var(--text-dim)', fontSize: 14 }}>
-          HomeLab Everywhere
+          {preset.productTagline}
         </span>
       </header>
 

--- a/frontend/src/components/AddTunnelModal.tsx
+++ b/frontend/src/components/AddTunnelModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { addTunnel } from '../api/client'
+import { preset } from '../preset'
 
 interface Props {
   onClose: () => void
@@ -37,8 +38,8 @@ type TunnelType = 'expose' | 'webhook'
 
 export function AddTunnelModal({ onClose, onAdded }: Props) {
   const [tunnelType, setTunnelType] = useState<TunnelType>('expose')
-  const [serviceUrl, setServiceUrl] = useState('')
-  const [label, setLabel] = useState('')
+  const [serviceUrl, setServiceUrl] = useState(preset.defaultServiceUrl)
+  const [label, setLabel] = useState(preset.defaultLabel)
   const [name, setName] = useState('')
   const [webhookPath, setWebhookPath] = useState('/webhook/')
   const [showAdvanced, setShowAdvanced] = useState(false)

--- a/frontend/src/preset.ts
+++ b/frontend/src/preset.ts
@@ -1,0 +1,47 @@
+/**
+ * Build-time preset selected via the `VITE_APP_MODE` env var.
+ *
+ * The same React build powers both the Home Assistant add-on and the standalone
+ * Docker UI. A small set of defaults — initial form values, copy strings —
+ * differs between the two. CI sets `VITE_APP_MODE` per-variant in
+ * `.github/workflows/build.yml` and consumes the produced `frontend/dist` into
+ * the matching tarball.
+ *
+ * Defaults to `docker` so a local `npm run dev` mirrors the standalone build.
+ */
+
+export type AppMode = 'ha-addon' | 'docker'
+
+export interface Preset {
+  appMode: AppMode
+  /** Pre-fills the "Service URL" field when adding a tunnel. */
+  defaultServiceUrl: string
+  /** Pre-fills the "Label" field when adding a tunnel. */
+  defaultLabel: string
+  /** Tagline shown next to the HLE logo in the header. */
+  productTagline: string
+  /** Short copy used in the empty-state and the Add Tunnel CTA. */
+  addTunnelCta: string
+}
+
+const PRESETS: Record<AppMode, Preset> = {
+  'ha-addon': {
+    appMode: 'ha-addon',
+    defaultServiceUrl: 'http://homeassistant.local.hass.io:8123',
+    defaultLabel: 'ha',
+    productTagline: 'for Home Assistant',
+    addTunnelCta: 'Expose Home Assistant',
+  },
+  docker: {
+    appMode: 'docker',
+    defaultServiceUrl: '',
+    defaultLabel: '',
+    productTagline: 'HomeLab Everywhere',
+    addTunnelCta: 'Add Tunnel',
+  },
+}
+
+const rawMode = import.meta.env.VITE_APP_MODE
+const mode: AppMode = rawMode === 'ha-addon' ? 'ha-addon' : 'docker'
+
+export const preset: Preset = PRESETS[mode]

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_MODE?: 'ha-addon' | 'docker'
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
The build workflow was producing two identical frontend tarballs (\`hle-frontend-docker\` and \`hle-frontend-ha-addon\`) with a comment saying \`VITE_APP_MODE not yet implemented\`. Wires up the preset so each variant carries its own copy and form defaults.

## Changes
- \`frontend/src/preset.ts\` — new module reading \`import.meta.env.VITE_APP_MODE\`. Exports a \`Preset\` with \`defaultServiceUrl\`, \`defaultLabel\`, \`productTagline\`, \`addTunnelCta\`. Defaults to \`docker\` for local dev.
- \`frontend/src/vite-env.d.ts\` — type declaration for \`VITE_APP_MODE\`.
- \`AddTunnelModal.tsx\` — prefills service URL + label from preset.
- \`App.tsx\` — header tagline reads from preset.
- \`build.yml\` — runs \`npm run build\` twice: once with \`VITE_APP_MODE=docker\` (also feeds the webapp tarball used by the docker image), once with \`VITE_APP_MODE=ha-addon\`. \`dist/\` is wiped between runs so artifacts don't bleed.

## Presets

| | docker | ha-addon |
|---|---|---|
| defaultServiceUrl | (empty) | \`http://homeassistant.local.hass.io:8123\` |
| defaultLabel | (empty) | \`ha\` |
| productTagline | \`HomeLab Everywhere\` | \`for Home Assistant\` |

## Test plan
- [ ] Local: \`npm run dev\` — Add Tunnel form has empty defaults, header shows \`HomeLab Everywhere\`
- [ ] Local: \`VITE_APP_MODE=ha-addon npm run build\` — bundle prefills HA defaults
- [ ] CI builds both tarballs successfully
- [ ] After merge + release: ha-addon receives correct preset bundle, hle-docker receives the docker bundle