### PR TITLE
feat: include hle-client version in webapp-release dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,22 +98,36 @@ jobs:
             hle-webapp-*.tar.gz
             hle-frontend-*.tar.gz
 
+      - name: Resolve hle-client version
+        id: client_version
+        run: |
+          CV=$(grep '^hle-client==' requirements.txt | sed 's/hle-client==//' | tr -d '[:space:]')
+          if [ -z "$CV" ]; then
+            echo "::error::could not parse hle-client version from requirements.txt"
+            exit 1
+          fi
+          echo "version=$CV" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch to ha-addon
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.HLE_PAT }}
           VERSION: ${{ steps.version.outputs.version }}
+          CLIENT_VERSION: ${{ steps.client_version.outputs.version }}
         run: |
           gh api repos/hle-world/ha-addon/dispatches \
             -f event_type=webapp-release \
-            -f "client_payload[version]=${VERSION}"
+            -f "client_payload[version]=${VERSION}" \
+            -f "client_payload[hle_client_version]=${CLIENT_VERSION}"
 
       - name: Dispatch to hle-docker
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.HLE_PAT }}
           VERSION: ${{ steps.version.outputs.version }}
+          CLIENT_VERSION: ${{ steps.client_version.outputs.version }}
         run: |
           gh api repos/hle-world/hle-docker/dispatches \
             -f event_type=webapp-release \
-            -f "client_payload[version]=${VERSION}"
+            -f "client_payload[version]=${VERSION}" \
+            -f "client_payload[hle_client_version]=${CLIENT_VERSION}"


### PR DESCRIPTION
## Summary
Extends the \`webapp-release\` repository_dispatch payload with \`hle_client_version\` (read from \`requirements.txt\`). ha-addon and hle-docker use it to keep their Dockerfile pins in sync.

## Why
The legacy fan-out in \`hle-client/publish.yml\` directly dispatched to ha-addon and hle-docker on every client release, which bypassed webapp validation and produced sync PRs out of order. That fan-out was removed in hle-client#79, but it left no automatic mechanism for ha-addon/hle-docker to learn about new hle-client versions. This PR is the missing replacement: webapp's release now carries that information forward.

The new chain is:

\`hle-client release → hle-webapp PR → hle-webapp release → ha-addon/hle-docker PR (frontend + pin)\`

## Companion PRs
- ha-addon#78: \`sync-frontend.yml\` reads \`hle_client_version\` and bumps \`hle/Dockerfile\`
- hle-docker#80: \`sync-webapp.yml\` reads \`hle_client_version\` and bumps \`Dockerfile\` + \`Dockerfile.headless\`

## Order of merge
The receivers (ha-addon, hle-docker) accept missing \`hle_client_version\` gracefully and fall back to frontend-only behavior. Sender (this PR) sends the field unconditionally. So order doesn't strictly matter, but merging receivers first means the next webapp release after this PR ships will already use the new flow end-to-end.

## Test plan
- [ ] Cut a release after merging all three PRs; verify ha-addon and hle-docker each get a PR that updates both their frontend assets and their Dockerfile pin in one commit