### PR TITLE
chore: bump hle-client to v2605.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==2605.1
+hle-client==2605.3
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
Automated sync from hle-client release vv2605.3.