### PR TITLE
Add PR-CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend compile + lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install backend deps
+        run: pip install -r requirements.txt
+
+      - name: Syntax check
+        run: python -m compileall -q backend
+
+      - name: Ruff (best-effort)
+        run: |
+          pip install ruff
+          ruff check backend || echo "::warning::ruff reported issues"
+
+  frontend:
+    name: Frontend typecheck + build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc -b --noEmit
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Adds `test.yml` so sync PRs (and any human PRs) actually have something to gate auto-merge on.

- **Backend**: `python -m compileall` + `ruff check` (advisory)
- **Frontend**: `tsc -b --noEmit` + `npm run build`

Conservative: ruff is best-effort (warns rather than fails) since there's no existing ruff config to baseline against.