### PR TITLE
Take tunnel state from relay API only, not log scraping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend compile + lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install backend deps
+        run: pip install -r requirements.txt
+
+      - name: Syntax check
+        run: python -m compileall -q backend
+
+      - name: Ruff (best-effort)
+        run: |
+          pip install ruff
+          ruff check backend || echo "::warning::ruff reported issues"
+
+  frontend:
+    name: Frontend typecheck + build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc -b --noEmit
+
+      - name: Build
+        run: npm run build

--- a/backend/tunnel_manager.py
+++ b/backend/tunnel_manager.py
@@ -145,18 +145,16 @@ def _is_running(proc: asyncio.subprocess.Process | None) -> bool:
 
 
 def _parse_status_line(cfg_id: str, line: str) -> None:
-    """Parse a CLI log line and update tunnel state accordingly.
+    """Extract server NOTICEs and the latest warning/error from a CLI log line.
 
-    The webapp formerly extracted the tunnel subdomain from the
-    ``url=https://...`` field of the ``Tunnel registered:`` log line.
-    Subdomain (and the rest of the live state) is now fetched
-    server-authoritatively via ``GET /api/tunnels/{subdomain}/status``
-    in :func:`_monitor_tunnel`, so this routine only tracks
-    connection-state transitions and server-pushed NOTICE messages.
+    Connection state is *not* inferred from logs — it is owned exclusively by
+    :func:`_monitor_tunnel`, which polls the relay's API and treats the
+    server's ``is_active`` as the source of truth. Log scraping for state
+    led to UI desyncs whenever a transient WARNING line (e.g. a benign
+    ``WS_FRAME for unknown stream_id`` close race) made the pill stay on
+    "Connecting" even though the relay reported the tunnel as healthy.
     """
     # Server NOTICEs are rendered by the CLI with a leading glyph + space.
-    # Match them first so a notice line never falls through to the
-    # WARNING/ERROR string heuristic below.
     glyph = line[:1]
     if glyph in _NOTICE_GLYPHS:
         message = line[1:].strip()
@@ -164,16 +162,7 @@ def _parse_status_line(cfg_id: str, line: str) -> None:
             _record_notice(cfg_id, _NOTICE_GLYPHS[glyph], message)
         return
 
-    if "Tunnel registered:" in line:
-        _connected.add(cfg_id)
-        _last_errors.pop(cfg_id, None)
-    elif "Connection lost:" in line:
-        _connected.discard(cfg_id)
-        _last_errors[cfg_id] = line
-    elif "Reconnecting in" in line:
-        _connected.discard(cfg_id)
-    elif "WARNING" in line or "ERROR" in line:
-        # Only store actual warning/error lines (not INFO traffic logs)
+    if "WARNING" in line or "ERROR" in line:
         _last_errors[cfg_id] = line
 
 


### PR DESCRIPTION
## Symptom
Tunnel UI stuck on "Connecting" / "Process running — connecting to relay…" even though the relay's `/_hle/status` reports the tunnel as `is_active: true` and traffic flows through it (visible in logs).

## Root cause
`_parse_status_line` inferred connection state from substring matches on hle-client log lines (`Tunnel registered:`, `Connection lost:`, `Reconnecting in`). A benign WARNING burst (e.g. `WS_FRAME for unknown stream_id` close races) plus log-ordering quirks made the state disagree with the relay's authoritative `is_active`.

## Fix
`_monitor_tunnel` (which already polls the relay) is now the sole writer of `_connected`. The log-scraping branch keeps reading NOTICEs and capturing the last WARNING/ERROR for display, but never touches state.

User-action endpoints (Start/Stop/Update/Remove) already `_connected.discard()` explicitly, so a fresh subprocess always starts in `CONNECTING` and flips to `CONNECTED` only when `_monitor_tunnel`'s Phase 1 poll (every 2s) sees the tunnel on the relay.