### PR TITLE
chore: bump hle-client to v2605.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==2605.5
+hle-client==2605.6
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
Automated sync from hle-client release vv2605.6. Auto-merge enabled — will merge when CI passes.