### PR TITLE
chore: bump hle-client to v2606.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hle-client==2605.6
+hle-client==2606.1
 fastapi
 uvicorn
 httpx


### PR DESCRIPTION
Automated sync from hle-client release vv2606.1. Auto-merge enabled — will merge when CI passes.